### PR TITLE
Address of Facultad de Ciencias

### DIFF
--- a/Lattice2021-PoS/Lat21-PoS.tex
+++ b/Lattice2021-PoS/Lat21-PoS.tex
@@ -14,12 +14,11 @@
   Hallerova aleja 7, 42000 Varaždin, Croatia}
 
 \affiliation[b]{
-Facultad de Ciencias, Universidad Nacional Autónoma de México \\
-??? A.P. 70-543, C.P. 04510 Distrito Federal ???, Mexico}
+Facultad de Ciencias, Universidad Nacional Autónoma de México \\A.P. 70-542, C.P. 04510 Ciudad de México, Mexico}
 
 \affiliation[c]{
 Instituto de Ciencias Nucleares, Universidad Nacional Autónoma de México \\
-A.P. 70-543, C.P. 04510 Distrito Federal, Mexico}
+A.P. 70-543, C.P. 04510 Ciudad de México, Mexico}
 
 \emailAdd{ivan.hip@gfv.unizg.hr}
 \emailAdd{jafanica@ciencias.unam.mx}


### PR DESCRIPTION
I added the address of Facultad de Ciencias and changed the name of the city, some years ago it was "Distrito Federal", but now it is officially "Ciudad de México".